### PR TITLE
Update entry.py

### DIFF
--- a/entry.py
+++ b/entry.py
@@ -26,6 +26,7 @@ _repo_url_link_map = {
     "random": r"https://github.com/purescript-python/purescript-random.py",
     "quickcheck": r"https://github.com/purescript-python/purescript-quickcheck.py",
     "record": r"https://github.com/purescript-python/purescript-record.py",
+    "aff": r"https://github.com/purescript-python/purescript-aff.py",
 }
 
 


### PR DESCRIPTION
`purescript-aff` is now out of alpha to beta. It passes most tests from the original `purescript-aff`, and those that do not pass seem to be because of delay values that are incorrectly calibrated for python. I have commented these tests out (there are 4-5) in the `purescript-aff.py` repo.